### PR TITLE
fix(mastodon): dont fetch reposts from APIs

### DIFF
--- a/backend/src/MastodonFetcher.php
+++ b/backend/src/MastodonFetcher.php
@@ -200,7 +200,7 @@ class MastodonFetcher
      */
     protected function buildStatusesUrl(string $instance, string $accountId, int $limit, ?string $maxId = null, ?string $sinceId = null): string
     {
-        $url = "$instance/api/v1/accounts/$accountId/statuses?limit=$limit";
+        $url = "$instance/api/v1/accounts/$accountId/statuses?limit=$limit&exclude_reblogs=true";
 
         if ($maxId) {
             $url .= "&max_id=$maxId";


### PR DESCRIPTION
Before we fetched all sorts of unrelated posts, docs: <https://docs.joinmastodon.org/methods/accounts/#statuses>